### PR TITLE
workflow: Add an overall status job

### DIFF
--- a/.github/workflows/build-and-push-images.yaml
+++ b/.github/workflows/build-and-push-images.yaml
@@ -9,19 +9,9 @@ on:
   push:
     branches:
       - main
-    paths:
-      - '.github/workflows/*'
-      - .devcontainer/Dockerfile.devtools
-      - .devcontainer/Dockerfile.ortools
-      - .devcontainer/Dockerfile
   pull_request:
     branches:
       - main
-    paths:
-      - '.github/workflows/*'
-      - .devcontainer/Dockerfile.devtools
-      - .devcontainer/Dockerfile.ortools
-      - .devcontainer/Dockerfile
 
 permissions:
   contents: read
@@ -96,3 +86,18 @@ jobs:
       aws_repository_role_arn: ${{ secrets.AWS_REPOSITORY_ROLE_ARN }}
     with:
       repository_name: ${{ needs.build-devcontainer.outputs.image }}
+
+  # collect all the jobs, and if any of them failed, fail the overall status,
+  # otherwise pass. this is a workaround because branch protection rule and path
+  # filters don't really play too well together.
+  build-and-push-overall-status-ok:
+    runs-on: ubuntu-latest
+    needs: [build-devtools, build-ortools, build-devcontainer, delete-temporary-ecr-repo-devtools, delete-temporary-ecr-repo-ortools, delete-temporary-ecr-repo-devcontainer]
+    if: always()
+    steps:
+      - name: All tests ok
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - name: Some tests failed
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1

--- a/.github/workflows/delete-ecr-repository.yaml
+++ b/.github/workflows/delete-ecr-repository.yaml
@@ -31,4 +31,4 @@ jobs:
         run: |
           aws ecr delete-repository \
             --repository-name ${{ inputs.repository_name }} \
-            --force
+            --force || true


### PR DESCRIPTION
Branch protection rules are a bit silly and you can only wait on individual jobs. That means (1) we have to enumerate them all (would be ok with terraform probably), but (2) if any of them are skipped due to our path filters then the PR would be blocked.

So we add a collection job at the end which reports the overall status, and we can wait on that.