### PR TITLE
Always log into both registries

### DIFF
--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -125,17 +125,18 @@ jobs:
           DOCKERFILE_PATH: ${{ inputs.dockerfile }}
           TAG_SUFFIX: -${{ matrix.architecture }}
           IMAGE_NAME: ${{ needs.should-run.outputs.image_name }}
-          REPOSITORY: ${{ (github.event_name != 'pull_request' || needs.should-run.outputs.run != 'true') && inputs.public_repo_prefix || secrets.private_repo_prefix }}
+          PUSH_REPOSITORY: ${{ (github.event_name != 'pull_request' || needs.should-run.outputs.run != 'true') && inputs.public_repo_prefix || secrets.private_repo_prefix }}
         with:
           project-name: ${{ env.PROJECT }}
-          env-vars-for-codebuild: "AWS_REGION, BUILD_ARGS, DOCKERFILE_PATH, IMAGE_NAME, REPOSITORY, TAG_SUFFIX"
+          env-vars-for-codebuild: "AWS_REGION, BUILD_ARGS, DOCKERFILE_PATH, IMAGE_NAME, PUSH_REPOSITORY, TAG_SUFFIX"
 
       - name: Stop Builds
         if: failure() || cancelled()
         continue-on-error: true
         run: |
-          aws codebuild batch-delete-builds \
-            --ids $(aws codebuild list-builds-for-project --project-name "${{ env.PROJECT }}" --query 'ids' --output text)
+          for id in $(aws codebuild list-builds-for-project --project-name "${{ env.PROJECT }}" --query 'ids' --output text); do
+            aws codebuild stop-build --id "$id"
+          done
 
   manifest:
     needs: [should-run, build-and-push]

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -17,20 +17,16 @@ phases:
       - echo "${DOCKERHUB_PASSWORD}" | docker login --username "${DOCKERHUB_USERNAME}" --password-stdin
       - echo Logging in to Amazon ECR...
       - aws --version
-      - |
-        if [ "${REPOSITORY#public.ecr.aws/*}" != "${REPOSITORY}" ]; then
-          aws ecr-public get-login-password --region "${AWS_REGION}" | docker login --username AWS --password-stdin public.ecr.aws
-        else
-          aws ecr get-login-password --region "${AWS_REGION}" | docker login --username AWS --password-stdin "${REPOSITORY}"
-        fi
+      - aws ecr-public get-login-password --region "${AWS_REGION}" | docker login --username AWS --password-stdin public.ecr.aws
+      - aws ecr get-login-password --region "${AWS_REGION}" | docker login --username AWS --password-stdin "${PRIVATE_REGISTRY}"
   build:
     commands:
       - set -e
       - echo Build started on `date`
       - echo Building the Docker image...
-      - docker build ${BUILD_ARGS} -t "${REPOSITORY}/${IMAGE_NAME}:${IMAGE_TAG}${TAG_SUFFIX}" -f "${DOCKERFILE_PATH}" .
+      - docker build ${BUILD_ARGS} -t "${PUSH_REPOSITORY}/${IMAGE_NAME}:${IMAGE_TAG}${TAG_SUFFIX}" -f "${DOCKERFILE_PATH}" .
   post_build:
     commands:
       - set -e
       - echo Build completed on "$(date)"
-      - docker push "${REPOSITORY}/${IMAGE_NAME}:${IMAGE_TAG}${TAG_SUFFIX}"
+      - docker push "${PUSH_REPOSITORY}/${IMAGE_NAME}:${IMAGE_TAG}${TAG_SUFFIX}"


### PR DESCRIPTION
I've set a secret in the codebuild project with the private registry name, should stop any monkeying with figuring out which ones are needed. Problem is when building the combined image you might need both: if one got skipped because it didn't change in the PR then we're supposed to fetch it from the public registry. But the workflow was only coded to log in to one or the other.