### PR TITLE
golangci-lint: Set a higher timeout

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,5 @@
+run:
+  timeout: 5m
+
+gocritic:
+  enabled-tags: [diagnostic, experimental, opinionated, performance, style]


### PR DESCRIPTION
We're getting timeout failures somtimes in actions. Nobody likes flakes, add a config to raise it..